### PR TITLE
Fix meta serialization in react `useForesights`

### DIFF
--- a/packages/foresightjs-react/src/hooks/useForesights.test.tsx
+++ b/packages/foresightjs-react/src/hooks/useForesights.test.tsx
@@ -250,4 +250,34 @@ describe("useForesights", () => {
       expect(enabledByName.b).toBe(false)
     })
   })
+
+  describe("meta option", () => {
+    it("patches when only an item's meta content changes", () => {
+      const cb = vi.fn()
+      const { rerender } = render(
+        <MultiProbe optionsArray={[{ name: "a", callback: cb, meta: { v: 1 } }]} />
+      )
+      updateElementOptionsSpy.mockClear()
+
+      rerender(<MultiProbe optionsArray={[{ name: "a", callback: cb, meta: { v: 2 } }]} />)
+
+      const metaCalls = updateElementOptionsSpy.mock.calls.filter(
+        c => (c[1].meta as { v?: number } | undefined)?.v === 2
+      )
+      expect(metaCalls.length).toBeGreaterThan(0)
+    })
+
+    it("does not re-patch when meta content is unchanged across renders", () => {
+      const cb = vi.fn()
+      const { rerender } = render(
+        <MultiProbe optionsArray={[{ name: "a", callback: cb, meta: { v: 1 } }]} />
+      )
+      updateElementOptionsSpy.mockClear()
+
+      // New object, identical content - must not trigger a patch.
+      rerender(<MultiProbe optionsArray={[{ name: "a", callback: cb, meta: { v: 1 } }]} />)
+
+      expect(updateElementOptionsSpy).not.toHaveBeenCalled()
+    })
+  })
 })

--- a/packages/foresightjs-react/src/hooks/useForesights.ts
+++ b/packages/foresightjs-react/src/hooks/useForesights.ts
@@ -11,6 +11,24 @@ const INITIAL_SNAPSHOT = createUnregisteredSnapshot(false)
 const NOOP_SUBSCRIBE = () => () => {}
 const EMPTY_SNAPSHOTS: ForesightElementState[] = []
 
+/**
+ * Serialize `meta` for the patch key so a change to its contents re-triggers the
+ * patch effect. Interpolating the object directly would always stringify to
+ * "[object Object]", hiding every content change. Falls back to String() when
+ * the object can't be serialized (e.g. circular references).
+ */
+const serializeMeta = (meta: Record<string, unknown> | undefined): string => {
+  if (!meta) {
+    return ""
+  }
+
+  try {
+    return JSON.stringify(meta)
+  } catch {
+    return String(meta)
+  }
+}
+
 type SlotEntry = {
   element: Element
   result: ForesightRegisterResult
@@ -104,7 +122,9 @@ export const useForesights = <T extends HTMLElement = HTMLElement>(
 
   // Patch options on existing registrations without tearing them down
   const patchKey = optionsArray
-    .map(o => `${o.reactivateAfter ?? ""},${o.name ?? ""},${o.meta ?? ""},${o.enabled ?? ""}`)
+    .map(
+      o => `${o.reactivateAfter ?? ""},${o.name ?? ""},${serializeMeta(o.meta)},${o.enabled ?? ""}`
+    )
     .join("|")
 
   useEffect(() => {


### PR DESCRIPTION
  ### Dropped meta updates (@foresightjs/react)
  `useForesights` built its patch key by interpolating `meta`, collapsing every object
  to `"[object Object]"`, so meta-content changes never re-patched. Now serialized into
  the key.