### PR TITLE
Performance optimizations for debugger

### DIFF
--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/control-panel.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/control-panel.ts
@@ -1,12 +1,12 @@
 import { LitElement, css, html } from "lit"
 import { customElement, state } from "lit/decorators.js"
-import { classMap } from "lit/directives/class-map.js"
 import { ForesightManager } from "js.foresight"
 
 import "./element-tab/element-tab"
 import "./base-tab/tab-selector"
 import "./log-tab/log-tab"
 import "./settings-tab/settings-tab"
+import { getEventLogStore } from "./log-tab/log-store"
 import type { ControllerTabs, Corner } from "../../types/types"
 import { ForesightDevtools } from "../foresight-devtools"
 
@@ -87,20 +87,12 @@ export class ControlPanel extends LitElement {
       overflow: hidden;
     }
 
-    .tab-container.hidden {
-      display: none;
-    }
-
     .tab-content {
       flex: 1;
       position: relative;
     }
 
     .tab-content > * {
-      display: none;
-    }
-
-    .tab-content > .active {
       display: flex;
       position: absolute;
       top: 0;
@@ -177,6 +169,8 @@ export class ControlPanel extends LitElement {
     this._abortController = new AbortController()
     const { signal } = this._abortController
 
+    getEventLogStore().attach()
+
     ForesightManager.instance.addEventListener(
       "deviceStrategyChanged",
       e => {
@@ -202,6 +196,7 @@ export class ControlPanel extends LitElement {
     super.disconnectedCallback()
     this._abortController?.abort()
     this._abortController = null
+    getEventLogStore().detach()
   }
 
   private getStoredTab(): ControllerTabs {
@@ -269,6 +264,22 @@ export class ControlPanel extends LitElement {
     return this.isMinimized ? "+" : "−"
   }
 
+  /**
+   * Only the active tab is mounted; hidden tabs would otherwise keep their
+   * manager listeners and element subscriptions running invisibly.
+   */
+  private renderActiveTab() {
+    switch (this.activeTab) {
+      case "elements":
+        return html`<element-tab></element-tab>`
+      case "settings":
+        return html`<settings-tab></settings-tab>`
+      case "logs":
+      default:
+        return html`<log-tab></log-tab>`
+    }
+  }
+
   protected render() {
     return html`
       <div class="control-wrapper ${this.corner} ${this.isMinimized ? "minimized" : ""}">
@@ -296,20 +307,18 @@ export class ControlPanel extends LitElement {
           </button>
         </div>
 
-        <div class="tab-container ${this.isMinimized ? "hidden" : ""}">
-          <tab-selector
-            .activeTab="${this.activeTab}"
-            @tab-change="${this._handleTabChange}"
-          ></tab-selector>
+        ${this.isMinimized
+          ? ""
+          : html`
+              <div class="tab-container">
+                <tab-selector
+                  .activeTab="${this.activeTab}"
+                  @tab-change="${this._handleTabChange}"
+                ></tab-selector>
 
-          <div class="tab-content">
-            <log-tab class=${classMap({ active: this.activeTab === "logs" })}></log-tab>
-            <element-tab class=${classMap({ active: this.activeTab === "elements" })}></element-tab>
-            <settings-tab
-              class=${classMap({ active: this.activeTab === "settings" })}
-            ></settings-tab>
-          </div>
-        </div>
+                <div class="tab-content">${this.renderActiveTab()}</div>
+              </div>
+            `}
       </div>
     `
   }

--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/element-tab/element-tab.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/element-tab/element-tab.ts
@@ -1,11 +1,9 @@
 import { css, html, LitElement } from "lit"
 import { customElement, state } from "lit/decorators.js"
-import { map } from "lit/directives/map.js"
+import { repeat } from "lit/directives/repeat.js"
 
 import type {
-  CallbackCompletedEvent,
   CallbackHits,
-  CallbackHitType,
   CallbackInvokedEvent,
   ElementRegisteredEvent,
   ElementUnregisteredEvent,
@@ -81,14 +79,8 @@ export class ElementTab extends LitElement {
     }
   `
 
-  @state()
-  private hitCount: CallbackHits = {
-    mouse: { hover: 0, trajectory: 0 },
-    scroll: { down: 0, left: 0, right: 0, up: 0 },
-    tab: { forwards: 0, reverse: 0 },
-    touch: 0,
-    viewport: 0,
-    total: 0,
+  private get hitCount(): CallbackHits {
+    return ForesightManager.instance.getManagerData.globalCallbackHits
   }
 
   @state() private sortDropdown: DropdownOption[]
@@ -102,9 +94,10 @@ export class ElementTab extends LitElement {
   private _elementSubscriptions: Map<ForesightElement, () => void> = new Map()
   private _pendingElementUpdates: Map<ForesightElement, ForesightElementState> = new Map()
   private _updateDebounceId: ReturnType<typeof setTimeout> | null = null
-  // Cached sorted element lists to avoid repeated filtering in render
-  private _cachedActiveElements: ElementListEntry[] = []
-  private _cachedInactiveElements: ElementListEntry[] = []
+  // Cached sorted element order; states are looked up at render time so the
+  // cache never holds stale state objects.
+  private _cachedActiveElements: ForesightElement[] = []
+  private _cachedInactiveElements: ForesightElement[] = []
   private _elementsCacheDirty = true
 
   constructor() {
@@ -211,6 +204,28 @@ export class ElementTab extends LitElement {
     return lines.join("\n")
   }
 
+  /**
+   * The list doesn't render element rects (only hit slop), so rect-only state
+   * patches — fired for every element on every scroll/resize tick — are
+   * filtered out before they can schedule any work.
+   */
+  private _affectsElementList(
+    previous: ForesightElementState,
+    next: ForesightElementState
+  ): boolean {
+    if (previous === next) {
+      return false
+    }
+
+    for (const key of Object.keys(next) as (keyof ForesightElementState)[]) {
+      if (key !== "elementBounds" && next[key] !== previous[key]) {
+        return true
+      }
+    }
+
+    return next.elementBounds.hitSlop !== previous.elementBounds.hitSlop
+  }
+
   private _subscribeToElement(element: ForesightElement): void {
     if (this._elementSubscriptions.has(element)) {
       return
@@ -218,10 +233,17 @@ export class ElementTab extends LitElement {
 
     const unsubscribe = ForesightManager.instance.subscribeToElement(element, () => {
       const state = ForesightManager.instance.registeredElements.get(element)
-      if (state && state.isRegistered) {
-        this._pendingElementUpdates.set(element, state)
-        this._scheduleDebouncedUpdate()
+      if (!state || !state.isRegistered) {
+        return
       }
+
+      const known = this._pendingElementUpdates.get(element) ?? this.elementListItems.get(element)
+      if (known && !this._affectsElementList(known, state)) {
+        return
+      }
+
+      this._pendingElementUpdates.set(element, state)
+      this._scheduleDebouncedUpdate()
     })
 
     if (unsubscribe) {
@@ -281,10 +303,11 @@ export class ElementTab extends LitElement {
       { signal }
     )
 
+    // The manager has already updated its global hit counters; just re-render.
     ForesightManager.instance.addEventListener(
       "callbackCompleted",
-      (e: CallbackCompletedEvent) => {
-        this.handleCallbackCompleted(e.hitType)
+      () => {
+        this.requestUpdate()
       },
       { signal }
     )
@@ -326,43 +349,27 @@ export class ElementTab extends LitElement {
       return
     }
 
-    // Apply all pending updates in one batch
+    // Apply all pending updates in one batch; the sort order only depends on
+    // membership, isActive and isIntersectingWithViewport.
     for (const [element, state] of this._pendingElementUpdates) {
+      const previous = this.elementListItems.get(element)
+      if (
+        !previous ||
+        previous.isActive !== state.isActive ||
+        previous.isIntersectingWithViewport !== state.isIntersectingWithViewport
+      ) {
+        this._elementsCacheDirty = true
+      }
+
       this.elementListItems.set(element, state)
     }
     this._pendingElementUpdates.clear()
-    this._elementsCacheDirty = true
     this.requestUpdate()
   }
 
   private updateElementListFromManager() {
     this.elementListItems = new Map(ForesightManager.instance.registeredElements)
     this._elementsCacheDirty = true
-  }
-
-  private handleCallbackCompleted(hitType: CallbackHitType) {
-    switch (hitType.kind) {
-      case "mouse":
-        this.hitCount.mouse[hitType.subType]++
-        break
-      case "tab":
-        this.hitCount.tab[hitType.subType]++
-        break
-      case "scroll":
-        this.hitCount.scroll[hitType.subType]++
-        break
-      case "touch":
-        this.hitCount.touch++
-        break
-      case "viewport":
-        this.hitCount.viewport++
-        break
-      default:
-        hitType satisfies never
-    }
-
-    this.hitCount.total++
-    this.requestUpdate()
   }
 
   private getSortedElements(): ElementListEntry[] {
@@ -396,15 +403,15 @@ export class ElementTab extends LitElement {
       return
     }
 
-    const active: ElementListEntry[] = []
-    const inactive: ElementListEntry[] = []
+    const active: ForesightElement[] = []
+    const inactive: ForesightElement[] = []
     for (const entry of this.getSortedElements()) {
       // Disabled elements are inactive too; their reason is shown as a badge on the
       // row rather than a separate section.
       if (entry.state.isActive) {
-        active.push(entry)
+        active.push(entry.element)
       } else {
-        inactive.push(entry)
+        inactive.push(entry.element)
       }
     }
     this._cachedActiveElements = active
@@ -412,13 +419,13 @@ export class ElementTab extends LitElement {
     this._elementsCacheDirty = false
   }
 
-  private get activeElements(): ElementListEntry[] {
+  private get activeElements(): ForesightElement[] {
     this._recomputeElementsCache()
 
     return this._cachedActiveElements
   }
 
-  private get inactiveElements(): ElementListEntry[] {
+  private get inactiveElements(): ForesightElement[] {
     this._recomputeElementsCache()
 
     return this._cachedInactiveElements
@@ -440,7 +447,7 @@ export class ElementTab extends LitElement {
   private renderElementSection(
     label: string,
     modifierClass: string,
-    elements: ElementListEntry[],
+    elements: ForesightElement[],
     collapsed: boolean,
     toggleCollapsed: () => void
   ) {
@@ -457,17 +464,25 @@ export class ElementTab extends LitElement {
           ${label} (${elements.length})
         </h3>
         ${!collapsed
-          ? map(
+          ? repeat(
               elements,
-              entry => html`
-                <single-element
-                  .element=${entry.element}
-                  .state=${entry.state}
-                  .isExpanded=${this.expandedElementIds.has(entry.state.id)}
-                  .onToggle=${this.handleElementToggle}
-                >
-                </single-element>
-              `
+              element => this.elementListItems.get(element)?.id ?? "",
+              element => {
+                const state = this.elementListItems.get(element)
+                if (!state) {
+                  return ""
+                }
+
+                return html`
+                  <single-element
+                    .element=${element}
+                    .state=${state}
+                    .isExpanded=${this.expandedElementIds.has(state.id)}
+                    .onToggle=${this.handleElementToggle}
+                  >
+                  </single-element>
+                `
+              }
             )
           : ""}
       </div>

--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/element-tab/reactivate-countdown.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/element-tab/reactivate-countdown.ts
@@ -39,7 +39,7 @@ export class ReactivateCountdown extends LitElement {
   ]
 
   @property({ attribute: false }) element!: ForesightElement
-  @property({ attribute: false, hasChanged: () => true }) state!: ForesightElementState
+  @property({ attribute: false }) state!: ForesightElementState
   @state()
   private remainingTime: number = 0
 

--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/element-tab/single-element.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/element-tab/single-element.ts
@@ -162,7 +162,7 @@ export class SingleElement extends LitElement {
   ]
 
   @property({ attribute: false }) element!: ForesightElement
-  @property({ attribute: false, hasChanged: () => true }) state!: ForesightElementState
+  @property({ attribute: false }) state!: ForesightElementState
   @property() isExpanded: boolean = false
   @property() onToggle: ((elementId: string) => void) | undefined
 

--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/log-tab/log-store.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/log-tab/log-store.ts
@@ -1,0 +1,186 @@
+import { ForesightManager } from "js.foresight"
+import type { ForesightEvent, ForesightEventMap } from "js.foresight"
+import {
+  safeSerializeEventData,
+  safeSerializeManagerData,
+  type SerializedEventData,
+} from "../../../helpers/safeSerializeEventData"
+import type { LogEvents, LoggingLocations } from "../../../types/types"
+import { ForesightDevtools } from "../../foresight-devtools"
+
+export const MAX_LOGS = 100
+
+export const EVENT_COLORS: Record<ForesightEvent, string> = {
+  elementRegistered: "#2196f3",
+  callbackInvoked: "#00bcd4",
+  callbackCompleted: "#4caf50",
+  elementUnregistered: "#ff9800",
+  managerSettingsChanged: "#f44336",
+  mouseTrajectoryUpdate: "#78909c",
+  scrollTrajectoryUpdate: "#607d8b",
+  deviceStrategyChanged: "#9c27b0",
+}
+
+/**
+ * Collects manager events into a log buffer outside the Lit tree, so logs
+ * keep accumulating while the log tab is unmounted (panel minimized or
+ * another tab active) and survive remounts.
+ */
+export class EventLogStore {
+  logs: Array<SerializedEventData> = []
+  logLocation: LoggingLocations
+  eventsEnabled: LogEvents
+  private logIdCounter: number = 0
+  private changeListeners: Set<() => void> = new Set()
+  private managerListeners: Map<
+    ForesightEvent,
+    (event: ForesightEventMap[ForesightEvent]) => void
+  > = new Map()
+  private isAttached: boolean = false
+
+  constructor() {
+    const {
+      logging: { logLocation, ...eventFlags },
+    } = ForesightDevtools.instance.devtoolsSettings
+    this.logLocation = logLocation
+    this.eventsEnabled = eventFlags
+  }
+
+  /** Start listening to manager events. Idempotent; called when the control panel mounts. */
+  attach(): void {
+    if (this.isAttached) {
+      return
+    }
+
+    this.isAttached = true
+    for (const [eventType, enabled] of Object.entries(this.eventsEnabled)) {
+      if (enabled) {
+        this.addManagerListener(eventType as ForesightEvent)
+      }
+    }
+  }
+
+  /** Stop listening to manager events; the collected logs are kept. */
+  detach(): void {
+    this.managerListeners.forEach((handler, eventType) => {
+      ForesightManager.instance.removeEventListener(eventType, handler)
+    })
+    this.managerListeners.clear()
+    this.isAttached = false
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.changeListeners.add(listener)
+
+    return () => this.changeListeners.delete(listener)
+  }
+
+  setLogLocation(location: LoggingLocations): void {
+    this.logLocation = location
+    this.notify()
+  }
+
+  setEventEnabled(eventType: ForesightEvent, enabled: boolean): void {
+    this.eventsEnabled = {
+      ...this.eventsEnabled,
+      [eventType]: enabled,
+    }
+    if (this.isAttached) {
+      if (enabled) {
+        this.addManagerListener(eventType)
+      } else {
+        this.removeManagerListener(eventType)
+      }
+    }
+
+    this.notify()
+  }
+
+  clear(): void {
+    this.logs = []
+    this.notify()
+  }
+
+  logManagerData(): void {
+    if (this.logLocation === "none") {
+      return
+    }
+
+    if (this.logLocation === "console" || this.logLocation === "both") {
+      console.log(ForesightManager.instance.getManagerData)
+    }
+
+    if (this.logLocation === "controlPanel" || this.logLocation === "both") {
+      this.addLog(
+        safeSerializeManagerData(
+          ForesightManager.instance.getManagerData,
+          (++this.logIdCounter).toString()
+        )
+      )
+    }
+  }
+
+  private addManagerListener(eventType: ForesightEvent): void {
+    if (this.managerListeners.has(eventType)) {
+      return
+    }
+
+    const handler = (event: ForesightEventMap[typeof eventType]) => {
+      this.handleEvent(eventType, event)
+    }
+    this.managerListeners.set(eventType, handler)
+    ForesightManager.instance.addEventListener(eventType, handler)
+  }
+
+  private removeManagerListener(eventType: ForesightEvent): void {
+    const handler = this.managerListeners.get(eventType)
+    if (handler) {
+      ForesightManager.instance.removeEventListener(eventType, handler)
+      this.managerListeners.delete(eventType)
+    }
+  }
+
+  private handleEvent<K extends ForesightEvent>(eventType: K, event: ForesightEventMap[K]): void {
+    if (this.logLocation === "none") {
+      return
+    }
+
+    if (this.logLocation === "console" || this.logLocation === "both") {
+      const color = EVENT_COLORS[eventType] || "#ffffff"
+      console.log(`%c[ForesightJS] ${eventType}`, `color: ${color}; font-weight: bold;`, event)
+    }
+
+    if (this.logLocation === "controlPanel" || this.logLocation === "both") {
+      const log = safeSerializeEventData(event, (++this.logIdCounter).toString())
+      if (log.type === "serializationError") {
+        console.error(log.error, log.errorMessage)
+
+        return
+      }
+
+      this.addLog(log)
+    }
+  }
+
+  private addLog(log: SerializedEventData): void {
+    this.logs.unshift(log)
+    if (this.logs.length > MAX_LOGS) {
+      this.logs.pop()
+    }
+
+    this.notify()
+  }
+
+  private notify(): void {
+    for (const listener of this.changeListeners) {
+      listener()
+    }
+  }
+}
+
+let storeInstance: EventLogStore | null = null
+
+/** Lazily created so importing this module doesn't initialize the devtools. */
+export const getEventLogStore = (): EventLogStore => {
+  return (storeInstance ??= new EventLogStore())
+}

--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/log-tab/log-tab.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/log-tab/log-tab.ts
@@ -1,13 +1,7 @@
-import { ForesightManager } from "js.foresight"
-import type { ForesightEvent, ForesightEventMap } from "js.foresight"
+import type { ForesightEvent } from "js.foresight"
 import { LitElement, css, html } from "lit"
 import { customElement, property, state } from "lit/decorators.js"
-import { map } from "lit/directives/map.js"
-import {
-  safeSerializeEventData,
-  safeSerializeManagerData,
-  type SerializedEventData,
-} from "../../../helpers/safeSerializeEventData"
+import { repeat } from "lit/directives/repeat.js"
 import {
   BOTH_SVG,
   CLEAR_SVG,
@@ -18,14 +12,14 @@ import {
   STATE_SVG,
   WARNING_SVG,
 } from "../../../svg/svg-icons"
-import type { LogEvents, LoggingLocations } from "../../../types/types"
-import { ForesightDevtools } from "../../foresight-devtools"
+import type { LoggingLocations } from "../../../types/types"
 import "../base-tab/chip"
 import "../base-tab/tab-content"
 import "../base-tab/tab-header"
 import "../copy-icon/copy-icon"
 import "../dropdown/multi-select-dropdown"
 import type { DropdownOption } from "../dropdown/single-select-dropdown"
+import { getEventLogStore, MAX_LOGS } from "./log-store"
 import "./single-log"
 
 @customElement("log-tab")
@@ -127,27 +121,16 @@ export class LogTab extends LitElement {
     `,
   ]
 
+  private store = getEventLogStore()
   @state() private logDropdown: DropdownOption[]
   @state() private filterDropdown: DropdownOption[]
-  @state() private logLocation: LoggingLocations
-  @state() private eventsEnabled: LogEvents
-  @state() private logs: Array<SerializedEventData> = []
   @state() private expandedLogIds: Set<string> = new Set()
-  private MAX_LOGS: number = 100
-  private logIdCounter: number = 0
 
   @property() noContentMessage: string = "No logs available"
-  private _abortController: AbortController | null = null
-  private _eventListeners: Map<ForesightEvent, (event: ForesightEventMap[ForesightEvent]) => void> =
-    new Map()
+  private _unsubscribeStore: (() => void) | null = null
 
   constructor() {
     super()
-    const {
-      logging: { logLocation, ...eventFlags },
-    } = ForesightDevtools.instance.devtoolsSettings
-    this.eventsEnabled = eventFlags
-    this.logLocation = logLocation
     this.logDropdown = [
       {
         value: "controlPanel",
@@ -228,47 +211,40 @@ export class LogTab extends LitElement {
   }
 
   private handleLogLocationChange = (value: string): void => {
-    this.logLocation = value as LoggingLocations
+    this.store.setLogLocation(value as LoggingLocations)
   }
 
   private handleFilterChange = (changedEventType: string, isEnabled: boolean): void => {
-    this.eventsEnabled = {
-      ...this.eventsEnabled,
-      [changedEventType]: isEnabled,
-    }
-    if (isEnabled) {
-      this.addForesightEventListener(changedEventType as ForesightEvent)
-    } else {
-      this.removeForesightEventListener(changedEventType as ForesightEvent)
-    }
+    this.store.setEventEnabled(changedEventType as ForesightEvent, isEnabled)
   }
 
   private getSelectedEventFilters(): string[] {
-    return Object.entries(this.eventsEnabled)
+    return Object.entries(this.store.eventsEnabled)
       .filter(([, enabled]) => enabled)
       .map(([eventType]) => eventType)
   }
 
   //TODO check if devtools is open, but is harder than I thought. Look into later
   private shouldShowPerformanceWarning(): boolean {
-    const hasConsoleOutput = this.logLocation === "console" || this.logLocation === "both"
+    const { logLocation, eventsEnabled } = this.store
+    const hasConsoleOutput = logLocation === "console" || logLocation === "both"
     const hasFrequentEvents =
-      this.eventsEnabled.mouseTrajectoryUpdate || this.eventsEnabled.scrollTrajectoryUpdate
+      eventsEnabled.mouseTrajectoryUpdate || eventsEnabled.scrollTrajectoryUpdate
 
     return hasConsoleOutput && hasFrequentEvents
   }
 
   private getNoLogsMessage(): string {
-    const enabledCount = Object.values(this.eventsEnabled).filter(Boolean).length
+    const enabledCount = Object.values(this.store.eventsEnabled).filter(Boolean).length
     if (enabledCount === 0) {
       return "Logging for all events is turned off"
     }
 
-    if (this.logLocation === "console") {
+    if (this.store.logLocation === "console") {
       return "No logs to display. Logging location is set to console - check browser console for events."
     }
 
-    if (this.logLocation === "none") {
+    if (this.store.logLocation === "none") {
       return "No logs to display. Logging location is set to none"
     }
 
@@ -287,139 +263,34 @@ export class LogTab extends LitElement {
   }
 
   private clearLogs(): void {
-    this.logs = []
+    this.store.clear()
     this.expandedLogIds.clear()
     this.noContentMessage = "Logs cleared"
   }
 
+  private logManagerData = (): void => {
+    this.store.logManagerData()
+  }
+
   connectedCallback(): void {
     super.connectedCallback()
-    this._abortController = new AbortController()
-    this.setupDynamicEventListeners()
+    this._unsubscribeStore = this.store.subscribe(() => this.requestUpdate())
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback()
-    this._abortController?.abort()
-    this.removeAllEventListeners()
-  }
-
-  private setupDynamicEventListeners(): void {
-    Object.entries(this.eventsEnabled).forEach(([eventType, enabled]) => {
-      if (enabled) {
-        this.addForesightEventListener(eventType as ForesightEvent)
-      }
-    })
-  }
-
-  private addForesightEventListener(eventType: ForesightEvent): void {
-    if (this._eventListeners.has(eventType)) {
-      return
-    }
-
-    const handler = (event: ForesightEventMap[typeof eventType]) => {
-      this.handleEvent(eventType, event)
-    }
-    this._eventListeners.set(eventType, handler)
-    ForesightManager.instance.addEventListener(eventType, handler, {
-      signal: this._abortController?.signal,
-    })
-  }
-
-  private removeForesightEventListener(eventType: ForesightEvent): void {
-    const handler = this._eventListeners.get(eventType)
-    if (handler) {
-      ForesightManager.instance.removeEventListener(eventType, handler)
-      this._eventListeners.delete(eventType)
-    }
-  }
-
-  private removeAllEventListeners(): void {
-    this._eventListeners.forEach((handler, eventType) => {
-      ForesightManager.instance.removeEventListener(eventType, handler)
-    })
-    this._eventListeners.clear()
-  }
-
-  //TODO fix these events and in single-log
-  private getEventColor(eventType: ForesightEvent): string {
-    const colorMap: Record<ForesightEvent, string> = {
-      elementRegistered: "#2196f3",
-      callbackInvoked: "#00bcd4",
-      callbackCompleted: "#4caf50",
-      elementUnregistered: "#ff9800",
-      managerSettingsChanged: "#f44336",
-      mouseTrajectoryUpdate: "#78909c",
-      scrollTrajectoryUpdate: "#607d8b",
-      deviceStrategyChanged: "#9c27b0",
-    }
-
-    return colorMap[eventType] || "#ffffff"
-  }
-
-  private handleEvent<K extends ForesightEvent>(eventType: K, event: ForesightEventMap[K]): void {
-    if (this.logLocation === "none") {
-      return
-    }
-
-    if (this.logLocation === "console" || this.logLocation === "both") {
-      const color = this.getEventColor(eventType)
-      console.log(`%c[ForesightJS] ${eventType}`, `color: ${color}; font-weight: bold;`, event)
-    }
-
-    if (this.logLocation === "controlPanel" || this.logLocation === "both") {
-      this.addEventLog(event)
-    }
-  }
-
-  private addLog(log: SerializedEventData) {
-    this.logs.unshift(log)
-    if (this.logs.length > this.MAX_LOGS) {
-      this.logs.pop()
-    }
-
-    this.requestUpdate()
-  }
-
-  private logManagerData(): void {
-    if (this.logLocation === "none") {
-      return
-    }
-
-    if (this.logLocation === "console" || this.logLocation === "both") {
-      console.log(ForesightManager.instance.getManagerData)
-    }
-
-    if (this.logLocation === "controlPanel" || this.logLocation === "both") {
-      this.addManagerLog()
-    }
-  }
-
-  private addManagerLog(): void {
-    const log = safeSerializeManagerData(
-      ForesightManager.instance.getManagerData,
-      (++this.logIdCounter).toString()
-    )
-    this.addLog(log)
-  }
-
-  private addEventLog<K extends ForesightEvent>(event: ForesightEventMap[K]): void {
-    const log = safeSerializeEventData(event, (++this.logIdCounter).toString())
-    if (log.type === "serializationError") {
-      console.error(log.error, log.errorMessage)
-
-      return
-    }
-
-    this.addLog(log)
+    this._unsubscribeStore?.()
+    this._unsubscribeStore = null
   }
 
   render() {
+    const logs = this.store.logs
+
     return html`
       <tab-header>
         <div slot="chips" class="chips-container">
-          <chip-element title="Number of logged events (Max ${this.MAX_LOGS})">
-            ${this.logs.length} events
+          <chip-element title="Number of logged events (Max ${MAX_LOGS})">
+            ${logs.length} events
           </chip-element>
         </div>
         <div slot="actions">
@@ -436,7 +307,7 @@ Consider using 'Control Panel' only for better performance."
             : ""}
           <single-select-dropdown
             .dropdownOptions="${this.logDropdown}"
-            .selectedOptionValue="${this.logLocation}"
+            .selectedOptionValue="${this.store.logLocation}"
             .onSelectionChange="${this.handleLogLocationChange}"
           ></single-select-dropdown>
 
@@ -455,25 +326,27 @@ Consider using 'Control Panel' only for better performance."
           <button
             class="single-button"
             title="Clear all logs"
-            ?disabled="${this.logs.length === 0}"
+            ?disabled="${logs.length === 0}"
             @click="${this.clearLogs}"
           >
             ${CLEAR_SVG}
           </button>
         </div>
       </tab-header>
-      <tab-content .noContentMessage=${this.noContentMessage} .hasContent=${!!this.logs.length}>
-        ${this.logs.length === 0
+      <tab-content .noContentMessage=${this.noContentMessage} .hasContent=${!!logs.length}>
+        ${logs.length === 0
           ? html`<div class="no-items">${this.getNoLogsMessage()}</div>`
-          : map(this.logs, log => {
-              return html`
+          : repeat(
+              logs,
+              log => log.logId,
+              log => html`
                 <single-log
                   .log=${log}
                   .isExpanded=${this.expandedLogIds.has(log.logId)}
                   .onToggle=${this.handleLogToggle}
                 ></single-log>
               `
-            })}
+            )}
       </tab-content>
     `
   }

--- a/packages/js.foresight-devtools/src/lit-entry/control-panel/log-tab/single-log.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/control-panel/log-tab/single-log.ts
@@ -1,6 +1,7 @@
 import { LitElement, html, css, PropertyValues } from "lit"
 import { customElement, property } from "lit/decorators.js"
 import type { SerializedEventData } from "../../../helpers/safeSerializeEventData"
+import { EVENT_COLORS } from "./log-store"
 import "../base-tab/expandable-item"
 
 @customElement("single-log")
@@ -112,18 +113,7 @@ export class SingleLog extends LitElement {
   }
 
   private getLogTypeColor(logType: string): string {
-    const colorMap: Record<string, string> = {
-      elementRegistered: "#2196f3",
-      callbackInvoked: "#00bcd4",
-      callbackCompleted: "#4caf50",
-      elementUnregistered: "#ff9800",
-      managerSettingsChanged: "#f44336",
-      mouseTrajectoryUpdate: "#78909c",
-      scrollTrajectoryUpdate: "#607d8b",
-      deviceStrategyChanged: "#9c27b0",
-    }
-
-    return colorMap[logType] || "#555"
+    return (EVENT_COLORS as Record<string, string>)[logType] || "#555"
   }
 
   private getEventDisplayName(eventType: string): string {

--- a/packages/js.foresight-devtools/src/lit-entry/debug-overlay/debug-overlay.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/debug-overlay/debug-overlay.ts
@@ -60,13 +60,20 @@ export class DebugOverlay extends LitElement {
           ? html`
               <mouse-trajectory ?hidden=${!this.showMouseTrajectory}></mouse-trajectory>
               <scroll-trajectory ?hidden=${!this.showScrollTrajectory}></scroll-trajectory>
-              <element-overlays
-                ?hidden=${!this.showElementOverlays}
-                .showNameTags=${this.showNameTags}
-              ></element-overlays>
             `
           : ""}
       </div>
+      <!-- element-overlays positions itself in document coordinates and must stay
+           outside #overlay-container: the fixed container would become its
+           containing block and pin it back to the viewport. -->
+      ${this._strategy === "mouse"
+        ? html`
+            <element-overlays
+              ?hidden=${!this.showElementOverlays}
+              .showNameTags=${this.showNameTags}
+            ></element-overlays>
+          `
+        : ""}
     `
   }
 }

--- a/packages/js.foresight-devtools/src/lit-entry/debug-overlay/element-overlays.ts
+++ b/packages/js.foresight-devtools/src/lit-entry/debug-overlay/element-overlays.ts
@@ -18,6 +18,10 @@ type HitSlop = ForesightElementState["elementBounds"]["hitSlop"]
 interface ElementOverlay {
   nameLabel: HTMLElement
   slopArea: HTMLElement
+  /** Last applied document-coordinate rect; unchanged means no style writes needed. */
+  lastSlopRect: { left: number; top: number; width: number; height: number } | null
+  /** Size + hit slop the cached border radius was computed for. */
+  lastRadiusKey: string | null
 }
 
 interface CallbackAnimation {
@@ -36,12 +40,16 @@ export class ElementOverlays extends LitElement {
 
   static styles = [
     css`
+      /* Anchored to the document origin (initial containing block), not the
+         viewport: overlays are placed in document coordinates so the compositor
+         moves them together with the page content during scroll, instead of
+         JS chasing the scroll position a frame behind. */
       :host {
-        position: fixed;
+        position: absolute;
         top: 0;
         left: 0;
-        width: 100%;
-        height: 100%;
+        width: 0;
+        height: 0;
         pointer-events: none;
         z-index: 9999;
       }
@@ -227,7 +235,7 @@ export class ElementOverlays extends LitElement {
     nameLabel.className = "name-label"
     this.containerElement.appendChild(slopArea)
     this.containerElement.appendChild(nameLabel)
-    const overlay = { nameLabel, slopArea }
+    const overlay = { nameLabel, slopArea, lastSlopRect: null, lastRadiusKey: null }
     this.overlayMap.set(element, overlay)
 
     return overlay
@@ -270,11 +278,36 @@ export class ElementOverlays extends LitElement {
     state: ForesightElementState
   ): void {
     const { expandedRect, hitSlop } = state.elementBounds
+    // The manager reports viewport-relative rects; convert to document
+    // coordinates, which stay constant during scroll.
+    const left = expandedRect.left + window.scrollX
+    const top = expandedRect.top + window.scrollY
+    const width = expandedRect.right - expandedRect.left
+    const height = expandedRect.bottom - expandedRect.top
+
+    const last = overlay.lastSlopRect
+    if (
+      last &&
+      last.left === left &&
+      last.top === top &&
+      last.width === width &&
+      last.height === height
+    ) {
+      return
+    }
+
+    overlay.lastSlopRect = { left, top, width, height }
+
     const { style } = overlay.slopArea
-    style.transform = `translate3d(${expandedRect.left}px, ${expandedRect.top}px, 0)`
-    style.width = `${expandedRect.right - expandedRect.left}px`
-    style.height = `${expandedRect.bottom - expandedRect.top}px`
-    style.borderRadius = this.expandedBorderRadius(element, hitSlop)
+    style.transform = `translate3d(${left}px, ${top}px, 0)`
+    style.width = `${width}px`
+    style.height = `${height}px`
+
+    const radiusKey = `${width}|${height}|${hitSlop.top}|${hitSlop.right}|${hitSlop.bottom}|${hitSlop.left}`
+    if (overlay.lastRadiusKey !== radiusKey) {
+      overlay.lastRadiusKey = radiusKey
+      style.borderRadius = this.expandedBorderRadius(element, hitSlop)
+    }
   }
 
   private updateNameLabel(overlay: ElementOverlay, state: ForesightElementState): void {
@@ -286,8 +319,8 @@ export class ElementOverlays extends LitElement {
     } else {
       nameLabel.textContent = state.name
       nameLabel.style.display = "block"
-      nameLabel.style.transform = `translate3d(${expandedRect.left}px, ${
-        expandedRect.top - 25
+      nameLabel.style.transform = `translate3d(${expandedRect.left + window.scrollX}px, ${
+        expandedRect.top - 25 + window.scrollY
       }px, 0)`
     }
   }


### PR DESCRIPTION
- Mount only the active devtools tab; skip tab container entirely when minimized
- Use keyed repeat instead of map for element + log lists (DOM reuse)
- Read hit counts from manager's global counters instead of duplicating state
- Drop hasChanged: () => true so unchanged state props don't force re-renders
- Move logs to singleton store outside Lit tree; logs persist while tab unmounted
- Hoist event color map to shared constant
- Position overlays in document coords (absolute) so compositor handles scroll, not JS