### PR TITLE
fix: only observe active elements on handler connect

### DIFF
--- a/packages/js.foresight/src/managers/DesktopHandler.ts
+++ b/packages/js.foresight/src/managers/DesktopHandler.ts
@@ -63,8 +63,10 @@ export class DesktopHandler extends ElementObservingModule {
 
     this.devLog(`Connected predictors: [${enabledPredictors.join(", ")}] and PositionObserver`)
 
-    for (const element of this.elements.keys()) {
-      this.positionObserver.observe(element)
+    for (const [element, entry] of this.elements) {
+      if (entry.state.isActive) {
+        this.positionObserver.observe(element)
+      }
     }
   }
 

--- a/packages/js.foresight/src/managers/TouchDeviceHandler.ts
+++ b/packages/js.foresight/src/managers/TouchDeviceHandler.ts
@@ -64,8 +64,10 @@ export class TouchDeviceHandler extends ElementObservingModule {
 
     this.predictor?.connect()
 
-    for (const element of this.elements.keys()) {
-      this.predictor?.observeElement(element)
+    for (const [element, entry] of this.elements) {
+      if (entry.state.isActive) {
+        this.predictor?.observeElement(element)
+      }
     }
   }
 


### PR DESCRIPTION
On connect, `DesktopHandler` and `TouchDeviceHandler` observed every registered element, while `registerElement` only observes active ones. After a device-strategy switch, disabled/parked/fired elements were observed again. Harmless (`callCallback` guards on `isActive`) but wasteful and inconsistent.

Both handlers now skip inactive elements, matching `registerElement`.