### PR TITLE
React: forward consumer ref in `Foresight`  "as" form

### DIFF
--- a/packages/devpage-framework/src/react/components/test-buttons/ForesightComponentButtons.tsx
+++ b/packages/devpage-framework/src/react/components/test-buttons/ForesightComponentButtons.tsx
@@ -1,6 +1,7 @@
 import { Foresight } from "@foresightjs/react"
 import ForesightStats from "../ui/ForesightStats"
 import { useReactivateAfter } from "../../stores/ButtonStateStore"
+import { useEffect, useRef } from "react"
 
 const callback = async () => {
   const randomTimeout = Math.floor(Math.random() * 1000)
@@ -12,12 +13,34 @@ const buttonClassName =
 
 export const ForesightButtonAs = () => {
   const reactivateAfter = useReactivateAfter()
+  const ref = useRef<HTMLButtonElement>(null)
+
+  // Proof the consumer ref reaches the real DOM node: write a marker onto it.
+  useEffect(() => {
+    if (!ref.current) {
+      return
+    }
+
+    ref.current.dataset.refProof = "ref-attached"
+    ref.current.title = `tagName: ${ref.current.tagName}`
+
+    ref.current.style.flexWrap = "wrap"
+
+    const proof = document.createElement("span")
+    proof.textContent = "ref works ✓"
+    proof.style.width = "100%"
+    proof.style.textAlign = "center"
+    ref.current.appendChild(proof)
+
+    return () => proof.remove()
+  }, [])
 
   return (
     <article className="flex flex-col items-center gap-3 w-40">
       <h4 className="text-sm font-medium text-gray-900 self-start">as=&quot;button&quot;</h4>
       <Foresight
         as="button"
+        ref={ref}
         foresightName="as-button"
         hitSlop={20}
         reactivateAfter={reactivateAfter}

--- a/packages/docs/docs/react/foresight-component.md
+++ b/packages/docs/docs/react/foresight-component.md
@@ -37,9 +37,7 @@ function CheckoutButton() {
 
 `as` accepts any element tag (`"button"`, `"a"`, `"div"`, ...) or a component that forwards its ref to a DOM element.
 
-:::note
-In the `as` form there is no way to pass your own `ref` to the rendered element, `Foresight` uses the ref slot for its registration. If you need the DOM node, use the render-prop form below and attach both refs yourself.
-:::
+You can pass your own `ref` (object or callback) to the rendered element. It is merged with the internal registration ref, so you keep direct access to the DOM node while `Foresight` still registers it.
 
 ### Reading state in `as` form
 

--- a/packages/foresightjs-react/src/components/Foresight.test.tsx
+++ b/packages/foresightjs-react/src/components/Foresight.test.tsx
@@ -191,5 +191,31 @@ describe("Foresight", () => {
       unmount()
       expect(unregisterSpy).toHaveBeenCalledTimes(1)
     })
+
+    it("merges a consumer ref object with the registration ref", () => {
+      const ref = { current: null as HTMLButtonElement | null }
+      const { getByTestId } = render(
+        <Foresight as="button" data-testid="btn" ref={ref} callback={vi.fn()}>
+          Checkout
+        </Foresight>
+      )
+
+      const button = getByTestId("btn")
+      expect(ref.current).toBe(button)
+      expect(registerSpy.mock.calls[0][0].element).toBe(button)
+    })
+
+    it("merges a consumer callback ref with the registration ref", () => {
+      const callbackRef = vi.fn()
+      const { getByTestId } = render(
+        <Foresight as="button" data-testid="btn" ref={callbackRef} callback={vi.fn()}>
+          Checkout
+        </Foresight>
+      )
+
+      const button = getByTestId("btn")
+      expect(callbackRef).toHaveBeenCalledWith(button)
+      expect(registerSpy.mock.calls[0][0].element).toBe(button)
+    })
   })
 })

--- a/packages/foresightjs-react/src/components/Foresight.tsx
+++ b/packages/foresightjs-react/src/components/Foresight.tsx
@@ -1,4 +1,14 @@
-import type { ComponentPropsWithoutRef, CSSProperties, ElementType, ReactNode } from "react"
+import { forwardRef, useCallback } from "react"
+import type {
+  ComponentPropsWithoutRef,
+  ComponentPropsWithRef,
+  CSSProperties,
+  ElementType,
+  ForwardedRef,
+  ForwardRefRenderFunction,
+  ReactNode,
+  Ref,
+} from "react"
 import type { ForesightElementState } from "js.foresight"
 import { useForesightRegistration } from "../hooks/useForesightRegistration"
 import { useForesightState } from "../hooks/useForesightState"
@@ -30,46 +40,22 @@ export type ForesightAsProps<E extends ElementType> = ForesightComponentOptions 
     keyof ForesightComponentOptions | "as" | "children" | "className" | "style"
   >
 
-/**
- * Component form of useForesight: one instance, one registration.
- *
- * With `as`, it renders that element itself and forwards the remaining props
- * to it, including the HTML `name` attribute (the foresight name is
- * `foresightName`). It mirrors the element state onto `data-predicted`,
- * `data-active`, `data-callback-running` and `data-status` attributes via
- * direct DOM mutation, so plain CSS can style predictions. `children`,
- * `className` and `style` may also be functions of the reactive state:
- *
- * ```tsx
- * <Foresight
- *   as="button"
- *   callback={() => prefetch("/checkout")}
- *   onClick={checkout}
- *   className="checkout data-predicted:outline-amber-500"
- * >
- *   Checkout
- * </Foresight>
- * ```
- *
- * With a function as children and no `as`, it renders nothing itself and
- * passes the reactive state plus the elementRef to attach, giving full
- * control over the markup:
- *
- * ```tsx
- * <Foresight callback={() => prefetch(item.url)}>
- *   {({ elementRef, isPredicted }) => (
- *     <a ref={elementRef} href={item.url} className={isPredicted ? "predicted" : ""}>
- *       {item.name}
- *     </a>
- *   )}
- * </Foresight>
- * ```
- */
-export function Foresight<T extends HTMLElement = HTMLElement>(props: ForesightProps<T>): ReactNode
-export function Foresight<E extends ElementType>(props: ForesightAsProps<E>): ReactNode
-export function Foresight(props: ForesightProps | ForesightAsProps<ElementType>): ReactNode {
-  return props.as ? <ForesightElement {...props} /> : <ForesightRenderProp {...props} />
+type ForesightComponent = {
+  <T extends HTMLElement = HTMLElement>(props: ForesightProps<T>): ReactNode
+  <E extends ElementType>(
+    props: ForesightAsProps<E> & { ref?: ComponentPropsWithRef<E>["ref"] }
+  ): ReactNode
 }
+
+const renderForesight = (
+  props: ForesightProps | ForesightAsProps<ElementType>,
+  ref: ForwardedRef<HTMLElement>
+): ReactNode =>
+  props.as ? <ForesightElement {...props} forwardedRef={ref} /> : <ForesightRenderProp {...props} />
+
+export const Foresight = forwardRef(
+  renderForesight as ForwardRefRenderFunction<HTMLElement, never>
+) as unknown as ForesightComponent
 
 // Change name to foresightName for the component form, so the HTML name attribute can be forwarded to the element in the `as` form.
 const toRegistrationOptions = ({
@@ -92,7 +78,10 @@ const ForesightRenderProp = <T extends HTMLElement>({
   return children({ elementRef, ...state })
 }
 
-const ForesightElement = (props: ForesightAsProps<ElementType>): ReactNode => {
+const ForesightElement = ({
+  forwardedRef,
+  ...props
+}: ForesightAsProps<ElementType> & { forwardedRef: ForwardedRef<HTMLElement> }): ReactNode => {
   const {
     as: Tag,
     children,
@@ -122,6 +111,8 @@ const ForesightElement = (props: ForesightAsProps<ElementType>): ReactNode => {
 
   const { elementRef, registerResults } = useForesightRegistration(options)
 
+  const mergedRef = useMergedRef(elementRef, forwardedRef)
+
   // Subscribe only when something actually reads the state, so a fully static
   // element does not re-render on state changes
   const readsState =
@@ -134,9 +125,25 @@ const ForesightElement = (props: ForesightAsProps<ElementType>): ReactNode => {
       {...domProps}
       className={typeof className === "function" ? className(state) : className}
       style={typeof style === "function" ? style(state) : style}
-      ref={elementRef}
+      ref={mergedRef}
     >
       {typeof children === "function" ? children(state) : children}
     </Tag>
   )
 }
+
+const useMergedRef = <T extends HTMLElement>(
+  registrationRef: (node: T | null) => void,
+  userRef: Ref<T> | undefined
+): ((node: T | null) => void) =>
+  useCallback(
+    (node: T | null) => {
+      registrationRef(node)
+      if (typeof userRef === "function") {
+        userRef(node)
+      } else if (userRef) {
+        userRef.current = node
+      }
+    },
+    [registrationRef, userRef]
+  )


### PR DESCRIPTION
The as form of `Foresight` now accepts your own ref (object or callback), merged with the internal registration ref, so you can keep direct DOM  access while foresight still registers the element. 