### PR TITLE
Doc site homepage: fix small screen clipping issue

### DIFF
--- a/packages/docs/src/components/Hero/frameworkinstall.module.css
+++ b/packages/docs/src/components/Hero/frameworkinstall.module.css
@@ -10,6 +10,7 @@
 .tabsHeader {
   display: flex;
   border-bottom: 1px solid var(--site-border);
+  overflow-x: auto;
 }
 
 .tab {

--- a/packages/docs/src/components/Hero/hero.module.css
+++ b/packages/docs/src/components/Hero/hero.module.css
@@ -127,4 +127,7 @@
   .heroTitle {
     font-size: 2rem;
   }
+  .heroDemo {
+    max-width: calc(100vw - 50px);
+  }
 }


### PR DESCRIPTION
Fixes for two interrelated visual issues effecting the homepage on small screens (e.g. smaller phones):
1. The framework installation tabs can't be interacted with if offscreen; I added scrolling.
2. The entire hero section was getting clipped offscreen below about 450px or so.

Before:
<img width="386" height="871" alt="Screenshot 2026-07-14 at 4 09 00 PM" src="https://github.com/user-attachments/assets/4388b15e-180f-438f-bbda-65fb61b617a6" />

After:
<img width="386" height="871" alt="Screenshot 2026-07-14 at 4 08 47 PM" src="https://github.com/user-attachments/assets/0c0e2e8c-ffab-42e3-a28f-c86f278d96ff" />